### PR TITLE
Résolution typo alert-info début inscriptions

### DIFF
--- a/LanAdept/Views/Place/Liste.cshtml
+++ b/LanAdept/Views/Place/Liste.cshtml
@@ -144,7 +144,7 @@ else
 {
     <div class="alert alert-info">
         Les réservations de places ne sont pas encore débutées! Elles débuteront
-        @Model.Settings.PlaceReservationStartDate.ToString("dddd le d MMMM à H\\hmm", System.Globalization.CultureInfo.CreateSpecificCulture("fr-CA")) @* Jour *@
+        @Model.Settings.PlaceReservationStartDate.ToString("le dddd d MMMM à H\\hmm", System.Globalization.CultureInfo.CreateSpecificCulture("fr-CA")) @* Jour *@
     </div>
 }
 


### PR DESCRIPTION
On doit écrire (en français du moins) "le mercredi 4" au lieu de "mercredi le 4".
Référence banque de dépannage linguistique de l'Office québécois de la langue francaise: http://bdl.oqlf.gouv.qc.ca/bdl/gabarit_bdl.asp?id=4552